### PR TITLE
time setting example in latin america

### DIFF
--- a/.cspell.config.json
+++ b/.cspell.config.json
@@ -4,7 +4,7 @@
     "language": "en-GB",
 
     "dictionaries": [
-        // Makes cSpell only use the British spelling of words
+    // Makes cSpell only use the British spelling of words
         "!en_US"
     ],
     // List of words to be always considered correct

--- a/.env
+++ b/.env
@@ -51,4 +51,22 @@ CACHE_MAX_AGE=3650d
 
 ## Set the timezone for the docker containers, useful for correct timestamps on logs (default Europe/London)
 ## Formatted as tz database names. Example: Europe/Oslo or America/Los_Angeles
+## | País                 | Zona horaria (TZ)                |
+| -------------------- | -------------------------------- |
+| México (CDMX)        | `America/Mexico_City`            |
+| Argentina            | `America/Argentina/Buenos_Aires` |
+| Chile (Santiago)     | `America/Santiago`               |
+| Colombia             | `America/Bogota`                 |
+| Perú                 | `America/Lima`                   |
+| Venezuela            | `America/Caracas`                |
+| Uruguay              | `America/Montevideo`             |
+| Paraguay             | `America/Asuncion`               |
+| Bolivia              | `America/La_Paz`                 |
+| Ecuador              | `America/Guayaquil`              |
+| Panamá               | `America/Panama`                 |
+| Costa Rica           | `America/Costa_Rica`             |
+| Guatemala            | `America/Guatemala`              |
+| República Dominicana | `America/Santo_Domingo`          |
+##
+
 TZ=America/Lima

--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ CACHE_ROOT=./lancache
 ## If you have more storage, you'll likely want to increase this.
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
+## El tamaño del disco maximo tiene que ser fisico no supere el 90%
 CACHE_DISK_SIZE=2000g
 
 ## Sets the minimum free disk space that must be kept at all times.
@@ -40,4 +41,4 @@ CACHE_MAX_AGE=3650d
 
 ## Set the timezone for the docker containers, useful for correct timestamps on logs (default Europe/London)
 ## Formatted as tz database names. Example: Europe/Oslo or America/Los_Angeles
-TZ=Europe/London
+TZ=America/Los_Angeles

--- a/.env
+++ b/.env
@@ -7,13 +7,14 @@ USE_GENERIC_CACHE=true
 ## IP addresses that the lancache monolithic instance is reachable on
 ## Specify one or more IPs, space separated - these will be used when resolving DNS hostnames through lancachenet-dns. Multiple IPs can improve cache priming performance for some services (e.g. Steam)
 ## Note: This setting only affects DNS, monolithic and sniproxy will still bind to all IPs by default
-LANCACHE_IP=10.0.39.1
+LANCACHE_IP=192.168.1.10
 
 ## IP address on the host that the DNS server should bind to
-DNS_BIND_IP=10.0.39.1
+DNS_BIND_IP=192.168.1.10
 
 ## DNS Resolution for forwarded DNS lookups
-UPSTREAM_DNS=8.8.8.8
+## DNS DE CLOUDFLARE ES MAS RAPIDO QUE EL DNS DE GOOGLE
+UPSTREAM_DNS=1.1.1.1
 
 ## Storage path for the cached data
 ## Note that by default, this will be a folder relative to the docker-compose.yml file
@@ -24,21 +25,30 @@ CACHE_ROOT=./lancache
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
 ## El tamaño del disco maximo tiene que ser fisico no supere el 90%
-CACHE_DISK_SIZE=2000g
+CACHE_DISK_SIZE=890g
 
 ## Sets the minimum free disk space that must be kept at all times.
 ## When the available free space drops below the set amount for any reason,
 ## the cache server will begin pruning content to free up space.
 ## Prevents accidentally running out of disk space if CACHE_DISK_SIZE is set too high.
+--------------------------------------------------------------------------------------------------------------------
+## Establece el espacio libre mínimo en disco que debe mantenerse en todo momento.
+## Cuando el espacio libre disponible cae por debajo de la cantidad establecida por cualquier motivo,
+## el servidor de caché comenzará a eliminar contenido para liberar espacio.
+## Evita quedarse sin espacio en disco accidentalmente si CACHE_DISK_SIZE se establece demasiado alto.
 MIN_FREE_DISK=10g
 
 ## Change this to allow sufficient index memory for the nginx cache manager (default 500m)
 ## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE
+---------------------------------------------------------------------------------------------------
+## Cambie esto para permitir suficiente memoria de índice para el administrador de caché de nginx (predeterminado: 500 m).
+## Recomendamos 250 m de memoria de índice por cada 1 TB de CACHE_DISK_SIZE.
 CACHE_INDEX_SIZE=500m
 
 ## Change this to limit the maximum age of cached content (default 3650d)
+## Cambie esto para limitar la edad máxima del contenido almacenado en caché (predeterminado 3650d)
 CACHE_MAX_AGE=3650d
 
 ## Set the timezone for the docker containers, useful for correct timestamps on logs (default Europe/London)
 ## Formatted as tz database names. Example: Europe/Oslo or America/Los_Angeles
-TZ=America/Los_Angeles
+TZ=America/Lima

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are a few ways to make your local network aware of the cache server.
 ## `UPSTREAM_DNS`
 This allows you to choose one or more IP addresses for upstream DNS resolution if a name is not matched by the `lancache-dns` service (e.g. non-cached services, local hostname resolution).
 
-Whichever resolver you choose depends on your network's requirements - if you don't need to provide internal DNS names, you can point `UPSTREAM_DNS` directly to an external resolver (the default is Google's DNS at `8.8.8.8`).
+Whichever resolver you choose depends on your network's requirements - if you don't need to provide internal DNS names, you can point `UPSTREAM_DNS` directly to an external resolver (the default is cloudflare DNS at `1.1.1.1`).
 
 If you run internal services on your network, you can set `UPSTREAM_DNS` to be your internal DNS resolver(s), semicolon separated (e.g. `192.168.0.1; 192.168.0.2`).
 
@@ -41,6 +41,7 @@ If you run internal services on your network, you can set `UPSTREAM_DNS` to be y
   - `8.8.4.4`
 - Cloudflare
   - `1.1.1.1`
+  - `1.0.0.1`
 - OpenDNS
   - `208.67.222.222`
   - `208.67.220.220`


### PR DESCRIPTION
The DNS server was changed to Cloudflare with 1.1.1.1